### PR TITLE
Fixed broken link, scraper may have hard maintenance issues.

### DIFF
--- a/facebookRawScrape.py
+++ b/facebookRawScrape.py
@@ -9,13 +9,13 @@ def FacebookScrape(search, pageNumber):
         page = urllib2.urlopen("https://www.facebook.com/public?query=" + search + "&init=ffs&nomc=0&page=" + pageNumber)
         soup = BeautifulSoup(page, 'lxml')
         comments = soup.find_all(string=lambda text:isinstance(text,Comment))
-
-        comment = comments[1];
+        
+	comment = comments[1];
     
         soup2 = BeautifulSoup(comment, 'lxml')
 
         linkTags = soup2.find_all('a')
-        
+
         stringLinks=[]
         
         for link in linkTags:
@@ -33,10 +33,12 @@ def FacebookScrape(search, pageNumber):
         for link in profileLinks:
             soup3 = BeautifulSoup(link, 'lxml')
             trueLinks.append(soup3.find('a').get('href'))    
-        
+	
+	print("Writing to file")
+	        
         f = open('result' + pageNumber + '.txt', 'w')
         f.write("Name   Link \n")
-            
+     
         for link in trueLinks:
             profileScrape(link, f)
             
@@ -45,11 +47,9 @@ def FacebookScrape(search, pageNumber):
             
             
 def profileScrape(link, f):
-    print("Starting scrape for " + link)
-    page = urllib2.urlopen(link)
-    soup = BeautifulSoup(page, 'lxml')
-    name = soup.find('a', class_='_8_2').text
-    f.write((name + " " + link + "\n").encode("UTF-8"))
-#       f = open('result.txt', 'w')
-#       f.write(links.encode("UTF-8"))
-#       f.close()
+	print("Starting scrape for " + link)
+	page = urllib2.urlopen(link)
+	soup = BeautifulSoup(page, 'lxml')
+
+	name = soup.find('a', class_='_2nlw').text
+	f.write((name + " " + link + "\n").encode("UTF-8"))

--- a/result1.txt
+++ b/result1.txt
@@ -1,29 +1,35 @@
 Name   Link 
-Jonathan Gomez (soy gay) https://www.facebook.com/josemiguel.gomezlopez.1426
-Jonathan Gomez (soy gay) https://www.facebook.com/josemiguel.gomezlopez.1426
+Jonathan Maicelo https://www.facebook.com/jonathan.maicelo.127
+Jonathan Maicelo https://www.facebook.com/jonathan.maicelo.127
 Jonathan Villanueva https://www.facebook.com/jonathan.villanueva.56614
 Jonathan Villanueva https://www.facebook.com/jonathan.villanueva.56614
-Jonathan Dela Piedra Orbuda https://www.facebook.com/jonathan.orbuda.0
-Jonathan Dela Piedra Orbuda https://www.facebook.com/jonathan.orbuda.0
-Jonathan Graffe Núñez https://www.facebook.com/jhonathan.graffe.16
-Jonathan Graffe Núñez https://www.facebook.com/jhonathan.graffe.16
-Jonathan Fronti (Dj Giuseppe) https://www.facebook.com/deejay.giuseppe.5
-Jonathan Fronti (Dj Giuseppe) https://www.facebook.com/deejay.giuseppe.5
+Jonathan King Sadler (King Hank) https://www.facebook.com/KingViralPost
+Jonathan King Sadler (King Hank) https://www.facebook.com/KingViralPost
+Jonathan Gomez (soy gay) https://www.facebook.com/josemiguel.gomezlopez.1426
+Jonathan Gomez (soy gay) https://www.facebook.com/josemiguel.gomezlopez.1426
 Jonathan Hernandez https://www.facebook.com/jonathan.hernandezsierra.9
 Jonathan Hernandez https://www.facebook.com/jonathan.hernandezsierra.9
+Jonathan Maicelo Romàn https://www.facebook.com/jonathan.maiceloroman.98
+Jonathan Maicelo Romàn https://www.facebook.com/jonathan.maiceloroman.98
+Jonathan Graffe Núñez https://www.facebook.com/jhonathan.graffe.16
+Jonathan Graffe Núñez https://www.facebook.com/jhonathan.graffe.16
+Jonathan Kan (靳民知) https://www.facebook.com/jonathan.m.kan
+Jonathan Kan (靳民知) https://www.facebook.com/jonathan.m.kan
+Jonathan Thomson (Lo Key) https://www.facebook.com/lo.kevelli
+Jonathan Thomson (Lo Key) https://www.facebook.com/lo.kevelli
+Jonathan Fronti (Dj Giuseppe) https://www.facebook.com/deejay.giuseppe.5
+Jonathan Fronti (Dj Giuseppe) https://www.facebook.com/deejay.giuseppe.5
+Jonathan Ward https://www.facebook.com/icon4x4
+Jonathan Ward https://www.facebook.com/icon4x4
 Jonathan Agassi https://www.facebook.com/jonathan.agassiii
 Jonathan Agassi https://www.facebook.com/jonathan.agassiii
 Jonathan Pramono (Berak Keren) https://www.facebook.com/berak.keren.54
 Jonathan Pramono (Berak Keren) https://www.facebook.com/berak.keren.54
-Jonathan Maicelo https://www.facebook.com/jonathan.maicelo.127
-Jonathan Maicelo https://www.facebook.com/jonathan.maicelo.127
-Jonathan Bolingi https://www.facebook.com/jonathan.bolingi
-Jonathan Bolingi https://www.facebook.com/jonathan.bolingi
-Jonathan Nez https://www.facebook.com/VicePresidentJonathanNez
-Jonathan Nez https://www.facebook.com/VicePresidentJonathanNez
-Jonathan Carroll https://www.facebook.com/jonathan.carroll.7509
-Jonathan Carroll https://www.facebook.com/jonathan.carroll.7509
-Jonathan Mahoto (just jumper) https://www.facebook.com/jonathan.mahoto
-Jonathan Mahoto (just jumper) https://www.facebook.com/jonathan.mahoto
-Jonathan Bolingi Merikani https://www.facebook.com/jonathan.merikani
-Jonathan Bolingi Merikani https://www.facebook.com/jonathan.merikani
+Jonathan Nazanin https://www.facebook.com/jonathannazanin
+Jonathan Nazanin https://www.facebook.com/jonathannazanin
+Jonathan Pitre https://www.facebook.com/jonathan.pitre.140
+Jonathan Pitre https://www.facebook.com/jonathan.pitre.140
+Jonathan Lopez (Oficial) https://www.facebook.com/jonathanlopezalicante
+Jonathan Lopez (Oficial) https://www.facebook.com/jonathanlopezalicante
+Jonathan Maicelo https://www.facebook.com/jonathan.maicelo.16
+Jonathan Maicelo https://www.facebook.com/jonathan.maicelo.16

--- a/result2.txt
+++ b/result2.txt
@@ -1,29 +1,37 @@
 Name   Link 
-Jonathan Meyer https://www.facebook.com/jonathan.meyer.754
-Jonathan Meyer https://www.facebook.com/jonathan.meyer.754
-Jonathan Mondragon (Hps Mexico) https://www.facebook.com/hps.mexico
-Jonathan Mondragon (Hps Mexico) https://www.facebook.com/hps.mexico
-Jonathan Chan https://www.facebook.com/jonathan.chan.581
-Jonathan Chan https://www.facebook.com/jonathan.chan.581
-Jonathan Pina https://www.facebook.com/jonathan.pina.50
-Jonathan Pina https://www.facebook.com/jonathan.pina.50
-Jonathan Ordoñez Aguilar https://www.facebook.com/jonathan.ordonezaguilar
-Jonathan Ordoñez Aguilar https://www.facebook.com/jonathan.ordonezaguilar
-Jonathan Partida https://www.facebook.com/jonathan.partida.56829
-Jonathan Partida https://www.facebook.com/jonathan.partida.56829
-Jonathan Jansen https://www.facebook.com/jonathan.jansen.923
-Jonathan Jansen https://www.facebook.com/jonathan.jansen.923
-Jonathan Ford https://www.facebook.com/people/Jonathan-Ford/100012995975552
-Jonathan Ford https://www.facebook.com/people/Jonathan-Ford/100012995975552
-Jonathan Young https://www.facebook.com/people/Jonathan-Young/100004593828158
-Jonathan Young https://www.facebook.com/people/Jonathan-Young/100004593828158
-Jonathan Bazzi https://www.facebook.com/jonathan.bazzi
-Jonathan Bazzi https://www.facebook.com/jonathan.bazzi
-Jonathan Depres Carpfishing https://www.facebook.com/jonathan.deprescarpfishing
-Jonathan Depres Carpfishing https://www.facebook.com/jonathan.deprescarpfishing
-Jonathan Nazanin https://www.facebook.com/jonathannazanin
-Jonathan Nazanin https://www.facebook.com/jonathannazanin
+Jonathan Carroll https://www.facebook.com/jonathan.carroll.7509
+Jonathan Carroll https://www.facebook.com/jonathan.carroll.7509
+Jonathan Hernandez (jehr) https://www.facebook.com/people/Jonathan-Hernandez/100003118160858
+Jonathan Hernandez (jehr) https://www.facebook.com/people/Jonathan-Hernandez/100003118160858
 Jonathan Rhys Meyers (Jrhysmeyersunofficialforfans) https://www.facebook.com/Jrhysmeyersunofficialforfans
 Jonathan Rhys Meyers (Jrhysmeyersunofficialforfans) https://www.facebook.com/Jrhysmeyersunofficialforfans
+Jonathan Mahoto (just jumper) https://www.facebook.com/jonathan.mahoto
+Jonathan Mahoto (just jumper) https://www.facebook.com/jonathan.mahoto
+Jonathan Rockwood Hoar https://www.facebook.com/jonathan.r.hoar
+Jonathan Rockwood Hoar https://www.facebook.com/jonathan.r.hoar
+Jonathan Cohen https://www.facebook.com/jonathan.cohen.73113
+Jonathan Cohen https://www.facebook.com/jonathan.cohen.73113
+Jonathan Bennett (BigHoss) https://www.facebook.com/jonathan.bennett.397948
+Jonathan Bennett (BigHoss) https://www.facebook.com/jonathan.bennett.397948
+Jonathan Bolingi Merikani https://www.facebook.com/jonathan.merikani
+Jonathan Bolingi Merikani https://www.facebook.com/jonathan.merikani
+Jonathan Edward Hartono https://www.facebook.com/jonathan.edward
+Jonathan Edward Hartono https://www.facebook.com/jonathan.edward
+Jonathan David Rangel (chichin) https://www.facebook.com/chichinoficial1
+Jonathan David Rangel (chichin) https://www.facebook.com/chichinoficial1
+Jonathan Azaziah https://www.facebook.com/maddcoldazaziahreborn
+Jonathan Azaziah https://www.facebook.com/maddcoldazaziahreborn
+Jonathan Falcone https://www.facebook.com/jonathan.falcone
+Jonathan Falcone https://www.facebook.com/jonathan.falcone
+Jonathan Ordoñez Aguilar https://www.facebook.com/jonathan.ordonezaguilar
+Jonathan Ordoñez Aguilar https://www.facebook.com/jonathan.ordonezaguilar
 Jonathan Papamarenghi https://www.facebook.com/jonathan.papamarenghi
 Jonathan Papamarenghi https://www.facebook.com/jonathan.papamarenghi
+Jonathan Grey https://www.facebook.com/people/Jonathan-Grey/100009054265505
+Jonathan Grey https://www.facebook.com/people/Jonathan-Grey/100009054265505
+Jonathan Gijoe Abonne-Toi Forget https://www.facebook.com/people/Jonathan-Gijoe-Abonne-Toi-Forget/100007902228942
+Jonathan Gijoe Abonne-Toi Forget https://www.facebook.com/people/Jonathan-Gijoe-Abonne-Toi-Forget/100007902228942
+Jonathan Ct ( Liider The Skate Famiily) https://www.facebook.com/jonathan.alexander.90857901
+Jonathan Ct ( Liider The Skate Famiily) https://www.facebook.com/jonathan.alexander.90857901
+Jonathan Maicelo https://www.facebook.com/jonathan.maicelo
+Jonathan Maicelo https://www.facebook.com/jonathan.maicelo

--- a/result3.txt
+++ b/result3.txt
@@ -1,29 +1,33 @@
 Name   Link 
-Jonathan Lopez (Oficial) https://www.facebook.com/jonathanlopezalicante
-Jonathan Lopez (Oficial) https://www.facebook.com/jonathanlopezalicante
-Jonathan Wright https://www.facebook.com/jonathan.s.wright.1
-Jonathan Wright https://www.facebook.com/jonathan.s.wright.1
-Jonathan Grazzioli https://www.facebook.com/jonathan.grazzioli
-Jonathan Grazzioli https://www.facebook.com/jonathan.grazzioli
-Jonathan Redrico https://www.facebook.com/jonathan.redrico
-Jonathan Redrico https://www.facebook.com/jonathan.redrico
-Jonathan Sparkle Silfver https://www.facebook.com/jonathan.s.silfver
-Jonathan Sparkle Silfver https://www.facebook.com/jonathan.s.silfver
-Jonathan Hernandez (jehr) https://www.facebook.com/people/Jonathan-Hernandez/100003118160858
-Jonathan Hernandez (jehr) https://www.facebook.com/people/Jonathan-Hernandez/100003118160858
-Jonathan Chocados https://www.facebook.com/jonathan.chocados
-Jonathan Chocados https://www.facebook.com/jonathan.chocados
-Jonathan Boyd https://www.facebook.com/jonathan.boyd.5817
-Jonathan Boyd https://www.facebook.com/jonathan.boyd.5817
-Jonathan St. Louis-Nahous https://www.facebook.com/jonathan.msl
-Jonathan St. Louis-Nahous https://www.facebook.com/jonathan.msl
-Jonathan Thorsell https://www.facebook.com/jonathan.thorsell
-Jonathan Thorsell https://www.facebook.com/jonathan.thorsell
-Jonathan Velasquez Ramirez https://www.facebook.com/jonathan.velasquezramirez
-Jonathan Velasquez Ramirez https://www.facebook.com/jonathan.velasquezramirez
-Jonathan Paradis https://www.facebook.com/ParadisJonathan
-Jonathan Paradis https://www.facebook.com/ParadisJonathan
-Jonathan Marambio Pérez https://www.facebook.com/jonathan.marambioperez
-Jonathan Marambio Pérez https://www.facebook.com/jonathan.marambioperez
-Jonathan Fernandez (El Chino Fernandez ) https://www.facebook.com/jonathanfdzmay
-Jonathan Fernandez (El Chino Fernandez ) https://www.facebook.com/jonathanfdzmay
+Jonathan Maberry https://www.facebook.com/jonathan.maberry.5
+Jonathan Maberry https://www.facebook.com/jonathan.maberry.5
+Jonathan Puma (TheBoss) https://www.facebook.com/jonathanbryan.Puma
+Jonathan Puma (TheBoss) https://www.facebook.com/jonathanbryan.Puma
+Jonathan Durand Folco https://www.facebook.com/jonathan.durand.folco
+Jonathan Durand Folco https://www.facebook.com/jonathan.durand.folco
+Jonathan Nez https://www.facebook.com/VicePresidentJonathanNez
+Jonathan Nez https://www.facebook.com/VicePresidentJonathanNez
+Jonathan Bazzi https://www.facebook.com/jonathan.bazzi
+Jonathan Bazzi https://www.facebook.com/jonathan.bazzi
+Jonathan Bennett https://www.facebook.com/jonathan.bennett.7127
+Jonathan Bennett https://www.facebook.com/jonathan.bennett.7127
+Jonathan Riviere https://www.facebook.com/jonathan.riviere
+Jonathan Riviere https://www.facebook.com/jonathan.riviere
+Jonathan Solo Barreto (Diana Navarro ) https://www.facebook.com/Jonathanestivenbarreto
+Jonathan Solo Barreto (Diana Navarro ) https://www.facebook.com/Jonathanestivenbarreto
+Jonathan Garrido Navarro https://www.facebook.com/jonathan.garridonavarro
+Jonathan Garrido Navarro https://www.facebook.com/jonathan.garridonavarro
+Jonathan Mondragon (Hps Mexico) https://www.facebook.com/hps.mexico
+Jonathan Mondragon (Hps Mexico) https://www.facebook.com/hps.mexico
+Jonathan Bolingi https://www.facebook.com/jonathan.bolingi
+Jonathan Bolingi https://www.facebook.com/jonathan.bolingi
+Jonathan Pierlet https://www.facebook.com/jonathan.pierlet
+Jonathan Pierlet https://www.facebook.com/jonathan.pierlet
+Jonathan Capponi https://www.facebook.com/jonathan.capponi
+Jonathan Capponi https://www.facebook.com/jonathan.capponi
+Jonathan Guerrero https://www.facebook.com/RichGangIII
+Jonathan Guerrero https://www.facebook.com/RichGangIII
+Jonathan Helbling https://www.facebook.com/jonathan.helbling
+Jonathan Helbling https://www.facebook.com/jonathan.helbling
+Jonathan Dominguez Suarez (Soy Andrea Suárez) https://www.facebook.com/jonathandsas
+Jonathan Dominguez Suarez (Soy Andrea Suárez) https://www.facebook.com/jonathandsas

--- a/result4.txt
+++ b/result4.txt
@@ -1,31 +1,39 @@
 Name   Link 
-Jonathan JR Rubain https://www.facebook.com/jonathan.j.rubain
-Jonathan JR Rubain https://www.facebook.com/jonathan.j.rubain
-Jonathan Amouriaux https://www.facebook.com/jonathan.amouriaux
-Jonathan Amouriaux https://www.facebook.com/jonathan.amouriaux
-Jonathan Jeremy Bygrave (Hebrew Slim) https://www.facebook.com/terraslim
-Jonathan Jeremy Bygrave (Hebrew Slim) https://www.facebook.com/terraslim
-Jonathan Gijoe Abonne-Toi Forget https://www.facebook.com/people/Jonathan-Gijoe-Abonne-Toi-Forget/100007902228942
-Jonathan Gijoe Abonne-Toi Forget https://www.facebook.com/people/Jonathan-Gijoe-Abonne-Toi-Forget/100007902228942
-Jonathan Hernandez (monkey ) https://www.facebook.com/jonathan.hernandez.3133
-Jonathan Hernandez (monkey ) https://www.facebook.com/jonathan.hernandez.3133
-Jonathan Thornton (Johnny) https://www.facebook.com/jonathan.thornton
-Jonathan Thornton (Johnny) https://www.facebook.com/jonathan.thornton
-Jonathan Lantin https://www.facebook.com/jonathan.b.lantin
-Jonathan Lantin https://www.facebook.com/jonathan.b.lantin
-Jonathan Ibarra https://www.facebook.com/jonathan.ibarra.334
-Jonathan Ibarra https://www.facebook.com/jonathan.ibarra.334
-Jonathan Garcia Herrera (Lemus) https://www.facebook.com/jonathan.garciaherrera.uker
-Jonathan Garcia Herrera (Lemus) https://www.facebook.com/jonathan.garciaherrera.uker
-Jonathan Phay (jhwphay) https://www.facebook.com/jphay
-Jonathan Phay (jhwphay) https://www.facebook.com/jphay
-Jonathan Mufibi Lidesu https://www.facebook.com/jonathanmufibi.lidesu
-Jonathan Mufibi Lidesu https://www.facebook.com/jonathanmufibi.lidesu
-Jonathan Haller (Isobel Ulquiorra) https://www.facebook.com/kalvaradoruiz2
-Jonathan Haller (Isobel Ulquiorra) https://www.facebook.com/kalvaradoruiz2
-Jonathan Mason https://www.facebook.com/jonathan.mason.94
-Jonathan Mason https://www.facebook.com/jonathan.mason.94
-Jonathan Aguilar (JackoRisitas) https://www.facebook.com/jonathan.aguilar.16503323
-Jonathan Aguilar (JackoRisitas) https://www.facebook.com/jonathan.aguilar.16503323
-Jonathan Poirier (Musique) https://www.facebook.com/JonathanPoirierOfficiel
-Jonathan Poirier (Musique) https://www.facebook.com/JonathanPoirierOfficiel
+Jonathan Pauker https://www.facebook.com/jonathan.pauker
+Jonathan Pauker https://www.facebook.com/jonathan.pauker
+Jonathan Jansen https://www.facebook.com/jonathan.jansen.923
+Jonathan Jansen https://www.facebook.com/jonathan.jansen.923
+Jonathan Cabral (deus é o dono do lugar) https://www.facebook.com/jonathan.siosi
+Jonathan Cabral (deus é o dono do lugar) https://www.facebook.com/jonathan.siosi
+Jonathan Diamant https://www.facebook.com/people/Jonathan-Diamant/100009209220113
+Jonathan Diamant https://www.facebook.com/people/Jonathan-Diamant/100009209220113
+Jonathan Henke (Alan) https://www.facebook.com/jonathan.henke3
+Jonathan Henke (Alan) https://www.facebook.com/jonathan.henke3
+Jonathan Vasquez https://www.facebook.com/joesvago
+Jonathan Vasquez https://www.facebook.com/joesvago
+Jonathan Kay https://www.facebook.com/jonkay88
+Jonathan Kay https://www.facebook.com/jonkay88
+Jonathan Marshall https://www.facebook.com/jonathan.marshall.94651
+Jonathan Marshall https://www.facebook.com/jonathan.marshall.94651
+Jonathan Laberge (Musique) https://www.facebook.com/jonathanlabergelavoie
+Jonathan Laberge (Musique) https://www.facebook.com/jonathanlabergelavoie
+Jonathan Lehmann https://www.facebook.com/jolehmann
+Jonathan Lehmann https://www.facebook.com/jolehmann
+Jonathan Greff https://www.facebook.com/people/Jonathan-Greff/100010884630708
+Jonathan Greff https://www.facebook.com/people/Jonathan-Greff/100010884630708
+Jonathan Gambela (Compte plein ) https://www.facebook.com/jojo.leguide
+Jonathan Gambela (Compte plein ) https://www.facebook.com/jojo.leguide
+Jonathan Fernandez (El Chino Fernandez ) https://www.facebook.com/jonathanfdzmay
+Jonathan Fernandez (El Chino Fernandez ) https://www.facebook.com/jonathanfdzmay
+Jonathan Maicelo https://www.facebook.com/jonathan.maicelo.18
+Jonathan Maicelo https://www.facebook.com/jonathan.maicelo.18
+Jonathan Hermoza Andresen https://www.facebook.com/jonathan.hermozagonzales
+Jonathan Hermoza Andresen https://www.facebook.com/jonathan.hermozagonzales
+Jonathan Thomas https://www.facebook.com/J.Tugga
+Jonathan Thomas https://www.facebook.com/J.Tugga
+Jonathan Anthony Wolfe https://www.facebook.com/diewolfe
+Jonathan Anthony Wolfe https://www.facebook.com/diewolfe
+Jonathan LLanes https://www.facebook.com/llanes77
+Jonathan LLanes https://www.facebook.com/llanes77
+Jonathan Larco https://www.facebook.com/jonathandavidlarco
+Jonathan Larco https://www.facebook.com/jonathandavidlarco

--- a/result5.txt
+++ b/result5.txt
@@ -1,33 +1,31 @@
 Name   Link 
-Jonathan Da Silva https://www.facebook.com/people/Jonathan-Da-Silva/100004027373308
-Jonathan Da Silva https://www.facebook.com/people/Jonathan-Da-Silva/100004027373308
-Jonathan Remillard https://www.facebook.com/jonathan.remillard.7
-Jonathan Remillard https://www.facebook.com/jonathan.remillard.7
-Gisele Jonathan (ModaMax  MissLady) https://www.facebook.com/gisele.jonathan
-Gisele Jonathan (ModaMax  MissLady) https://www.facebook.com/gisele.jonathan
-Jonathan McGraw https://www.facebook.com/jonathan.mcgraw.16
-Jonathan McGraw https://www.facebook.com/jonathan.mcgraw.16
-Jonathan Laberge (Musique) https://www.facebook.com/jonathanlabergelavoie
-Jonathan Laberge (Musique) https://www.facebook.com/jonathanlabergelavoie
-Jonathan So https://www.facebook.com/jonathan.so.75
-Jonathan So https://www.facebook.com/jonathan.so.75
-Jonathan Souza https://www.facebook.com/jonathansouza2015
-Jonathan Souza https://www.facebook.com/jonathansouza2015
-Jonathan Tejada (Nikki Pitt HD) https://www.facebook.com/predicciones.loterias
-Jonathan Tejada (Nikki Pitt HD) https://www.facebook.com/predicciones.loterias
-Jonathan Santana https://www.facebook.com/jonathan.santana.3110
-Jonathan Santana https://www.facebook.com/jonathan.santana.3110
-Jonathan Betancourt (Joner) https://www.facebook.com/joner.insane
-Jonathan Betancourt (Joner) https://www.facebook.com/joner.insane
-Jonathan Jared Bañuelos Gasca (Cinco Tres Del Pueblo Santa Grifa) https://www.facebook.com/Wazadp53
-Jonathan Jared Bañuelos Gasca (Cinco Tres Del Pueblo Santa Grifa) https://www.facebook.com/Wazadp53
 Jonathan Agustin Perez https://www.facebook.com/cuervo.n.blanco
 Jonathan Agustin Perez https://www.facebook.com/cuervo.n.blanco
-Jonathan Thomson (Lo Key) https://www.facebook.com/lo.kevelli
-Jonathan Thomson (Lo Key) https://www.facebook.com/lo.kevelli
-Jonathan Kan (靳民知) https://www.facebook.com/jonathan.m.kan
-Jonathan Kan (靳民知) https://www.facebook.com/jonathan.m.kan
-Jonathan Riviere https://www.facebook.com/jonathan.riviere
-Jonathan Riviere https://www.facebook.com/jonathan.riviere
-Jonathan Falcone https://www.facebook.com/jonathan.falcone
-Jonathan Falcone https://www.facebook.com/jonathan.falcone
+Jonathan So https://www.facebook.com/jonathan.so.75
+Jonathan So https://www.facebook.com/jonathan.so.75
+Jonathan Gauvin https://www.facebook.com/jonathan.gauvin.7
+Jonathan Gauvin https://www.facebook.com/jonathan.gauvin.7
+Jonathan Pina https://www.facebook.com/jonathan.pina.50
+Jonathan Pina https://www.facebook.com/jonathan.pina.50
+Jonathan Camacho https://www.facebook.com/jonathan.camacho.589100
+Jonathan Camacho https://www.facebook.com/jonathan.camacho.589100
+Jonathan Stephanie Corbitt https://www.facebook.com/people/Jonathan-Stephanie-Corbitt/100007582245630
+Jonathan Stephanie Corbitt https://www.facebook.com/people/Jonathan-Stephanie-Corbitt/100007582245630
+Jonathan Pria Gay https://www.facebook.com/ahamdcowokgay
+Jonathan Pria Gay https://www.facebook.com/ahamdcowokgay
+Jonathan Wright https://www.facebook.com/jonathan.s.wright.1
+Jonathan Wright https://www.facebook.com/jonathan.s.wright.1
+Jonathan Phay (jhwphay) https://www.facebook.com/jphay
+Jonathan Phay (jhwphay) https://www.facebook.com/jphay
+Jonathan Constantine https://www.facebook.com/ionaskonstantinou
+Jonathan Constantine https://www.facebook.com/ionaskonstantinou
+Jonathan Parker https://www.facebook.com/jonathan.parker.9480
+Jonathan Parker https://www.facebook.com/jonathan.parker.9480
+Jonathan Ford https://www.facebook.com/people/Jonathan-Ford/100012995975552
+Jonathan Ford https://www.facebook.com/people/Jonathan-Ford/100012995975552
+Jonathan Aguilar (JackoRisitas) https://www.facebook.com/jonathan.aguilar.16503323
+Jonathan Aguilar (JackoRisitas) https://www.facebook.com/jonathan.aguilar.16503323
+Jonathan Dominguez ( The New School ) https://www.facebook.com/jonathan.dominguez.5
+Jonathan Dominguez ( The New School ) https://www.facebook.com/jonathan.dominguez.5
+Jonathan Da Silva https://www.facebook.com/people/Jonathan-Da-Silva/100004027373308
+Jonathan Da Silva https://www.facebook.com/people/Jonathan-Da-Silva/100004027373308

--- a/test.py
+++ b/test.py
@@ -3,6 +3,4 @@ from facebookRawScrape import FacebookScrape, profileScrape
 print("Starting FacebookScrape")
 
 
-for x in range(1, 6):
-    print("Scrape # " + str(x))
-    FacebookScrape("jonathan", str(x))
+FacebookScrape("jonathan", 1)


### PR DESCRIPTION
Scraper broke because a class was not found on the webpage for a profile. After looking through the page, the class had been changed. This may be facebook trying to cycle classes to stop crawling.